### PR TITLE
Add warnings that will point out other problems

### DIFF
--- a/dm-dist-alfa/makefile
+++ b/dm-dist-alfa/makefile
@@ -1,4 +1,9 @@
-CFLAGS=-Werror -Wno-error=deprecated-declarations -Wno-error=implicit-function-declaration
+CFLAGS=-O1 -g -Wall -Werror -Wno-error=deprecated-declarations -Wno-error=implicit-function-declaration -Wno-error=char-subscripts -Wno-unused-but-set-variable -Wno-unused-value -Wno-unused-variable
+# bad ideas
+CFLAGS+=-Wno-error=parentheses -Wno-error=return-type -Wno-error=pointer-sign -Wno-error=dangling-else -Wno-error=missing-braces -Wno-error=unused-result -Wno-implicit-function-declaration
+# good, optional ideas!
+CFLAG+=-fsanitize=address -fno-omit-frame-pointer
+
 LDLIBS=-lcrypt
 HEADERFILES = structs.h utils.h comm.h interpreter.h db.h
 all: delplay dmserver


### PR DESCRIPTION
Turn on all warnings, and fail on warnings, then
turn off failing on warnings that REALLY ARE PROBLEMS, but
  can't be fixed right now (but these should be allowed to
  crash compilation in the future and that line should be
  removed),
and also turn on some good memory tests that will help debug
  memory problems (and should stay on for a while).